### PR TITLE
add %{Pid} std format string

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -43,6 +43,7 @@
 //                     Optimized formats: 2006/01/02, 15:04:05.000, 15:04:05.000000, 15:04:05.000000000
 //   %{Unix} - Returns the number of seconds elapsed since January 1, 1970 UTC.
 //   %{UnixNano} - Returns the number of nanoseconds elapsed since January 1, 1970 UTC.
+//   %{Pid} - Process ID of current process.
 //   %{FullFile} - Full source file path (e.g. /dev/project/file.go).
 //   %{File} - The source file name (e.g. file.go).
 //   %{ShortFile} - The short source file name (file without .go).

--- a/factorlog_test.go
+++ b/factorlog_test.go
@@ -2,7 +2,9 @@ package factorlog
 
 import (
 	"bytes"
+	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -23,9 +25,9 @@ var logTests = []struct {
 }{
 	{
 		// we can't use every verb here, because the test will fail
-		"%{FullFunction} [%{SEVERITY}:%{SEV}:%{File}:%{ShortFile}] %%{Message}%",
+		"%{FullFunction} [%{SEVERITY}:%{SEV}:%{File}:%{ShortFile}:%{Pid}] %%{Message}%",
 		"hello there!",
-		[]byte("github.com/kdar/factorlog.TestLog [ERROR:EROR:factorlog_test.go:factorlog_test] %hello there!%\n"),
+		[]byte("github.com/kdar/factorlog.TestLog [ERROR:EROR:factorlog_test.go:factorlog_test" + fmt.Sprintf("%d", os.Getpid()) + "] %hello there!%\n"),
 	},
 	{
 		"%{Message} %{File}",

--- a/formatter_std.go
+++ b/formatter_std.go
@@ -31,6 +31,7 @@ const (
 	vFile
 	vShortFile
 	vLine
+	vPid
 	vFullFunction
 	vPkgFunction
 	vFunction
@@ -79,6 +80,7 @@ var (
 		"File":         vFile,
 		"ShortFile":    vShortFile,
 		"Line":         vLine,
+		"Pid":          vPid,
 		"FullFunction": vFullFunction,
 		"PkgFunction":  vPkgFunction,
 		"Function":     vFunction,
@@ -330,6 +332,9 @@ func (f *StdFormatter) Format(context LogContext) []byte {
 			buf.Write(f.tmp[:n])
 		case vUnixNano:
 			n := I64toa(&f.tmp, 0, context.Time.UnixNano())
+			buf.Write(f.tmp[:n])
+		case vPid:
+			n := Itoa(&f.tmp, 0, context.Pid)
 			buf.Write(f.tmp[:n])
 		case vFullFile:
 			buf.WriteString(context.File)


### PR DESCRIPTION
Pid was already initialized into the log context but never used. This PR adds a
new simple format string %{Pid} to log the process id of the current process.